### PR TITLE
Fix malformed version string "1.18.1.1788.ebuild"

### DIFF
--- a/profiles/package.mask
+++ b/profiles/package.mask
@@ -3,4 +3,4 @@
 # 
 # https://forums.plex.tv/t/linux-pms-1-17-0-1709-hevc-10bit-hw-transcode-fails-to-fallback-to-software/463037/7
 #
-=media-tv/plex-media-server-1.18.1.1788.ebuild
+=media-tv/plex-media-server-1.18.1.1788


### PR DESCRIPTION
From eix:
invalid line 6 in /var/lib/layman/fkmclane/profiles/package.mask: "=media-tv/plex-media-server-1.18.1.1788.ebuild ..."
    malformed (primary at position 12) version string "1.18.1.1788.ebuild"
(looks like as if line was copied from ls output)